### PR TITLE
Updates feature gate to use new_zeroed_alloc

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,7 +7,7 @@
     maybe_uninit_uninit_array,
     maybe_uninit_slice,
     portable_simd,
-    new_uninit,
+    new_zeroed_alloc,
     str_from_utf16_endian,
     array_chunks,
     unsized_const_params

--- a/frontend/desktop/src/main.rs
+++ b/frontend/desktop/src/main.rs
@@ -1,6 +1,6 @@
 #![feature(
     step_trait,
-    new_uninit,
+    new_zeroed_alloc,
     slice_ptr_get,
     array_chunks,
     portable_simd,

--- a/frontend/web/crate/src/lib.rs
+++ b/frontend/web/crate/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unused_unit)]
-#![feature(new_uninit)]
+#![feature(new_zeroed_alloc)]
 
 mod audio;
 #[cfg(feature = "log")]

--- a/render/soft-2d/base/src/lib.rs
+++ b/render/soft-2d/base/src/lib.rs
@@ -4,7 +4,7 @@
     const_mut_refs,
     const_trait_impl,
     generic_const_exprs,
-    new_uninit,
+    new_zeroed_alloc,
     portable_simd
 )]
 #![warn(clippy::all)]

--- a/render/soft-2d/src/lib.rs
+++ b/render/soft-2d/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(generic_const_exprs, new_uninit, portable_simd)]
+#![feature(generic_const_exprs, new_zeroed_alloc, portable_simd)]
 #![warn(clippy::all)]
 #![allow(incomplete_features)]
 

--- a/render/soft-3d/src/lib.rs
+++ b/render/soft-3d/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(portable_simd, const_mut_refs, const_trait_impl, new_uninit)]
+#![feature(portable_simd, const_mut_refs, const_trait_impl, new_zeroed_alloc)]
 #![warn(clippy::all)]
 
 mod data;

--- a/render/wgpu-2d/src/lib.rs
+++ b/render/wgpu-2d/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(
-    new_uninit,
+    new_zeroed_alloc,
     generic_const_exprs,
     const_mut_refs,
     const_trait_impl,

--- a/render/wgpu-3d/src/lib.rs
+++ b/render/wgpu-3d/src/lib.rs
@@ -4,7 +4,7 @@
     portable_simd,
     array_windows,
     maybe_uninit_uninit_array,
-    new_uninit
+    new_zeroed_alloc
 )]
 #![warn(clippy::all)]
 


### PR DESCRIPTION
Needed in order to build with newest nightly

`new_zeroed_alloc` is a more specific version of `new_uninit` as introduced in:

https://github.com/rust-lang/rust/issues/129396

P.S. I only noticed this because I'm trying to build dust for NixOS. Any interest in a PR to put the NixOS package definitions alongside the source itself? It'd be a `nix` subdirectory, a `flake.nix` and a `flake.lock` that'd be added.